### PR TITLE
added the overrride option SpoolData to the description

### DIFF
--- a/manuals/en/main/director-resource-schedule-definitions.tex
+++ b/manuals/en/main/director-resource-schedule-definitions.tex
@@ -87,6 +87,11 @@ tells Bareos to use or not the Accurate code for the specific job. It can
 allow you to save memory and and CPU resources on the catalog server in some
 cases.
 
+\item [SpoolData=yes{\textbar}no]
+\index[dir]{SpoolData}
+\index[dir]{Directive!Spool Data}
+tells Bareos to use or not to use spooling for the specific job.
+
 \end{description}
 
 {\bf Date-time-specification} determines when the  Job is to be run. The


### PR DESCRIPTION
The SpoolData option was missing in the list of possible job-overrides.